### PR TITLE
Fix unhandled exception in Windows when deleting a watched folder

### DIFF
--- a/lib/watchers/node.iced
+++ b/lib/watchers/node.iced
@@ -22,6 +22,11 @@ class NodeWatcher extends EventEmitter
       watcher.on 'change', (event, filename) =>
         debug "fs.watch incoming change: event = %j, filename = %j", event, filename
         @emit 'change', relpath, filename, no
+
+      # In Windows, 'error' event is thrown on deleting a folder.
+      # Add empty handler to avoid crash.
+      watcher.on 'error', (error) ->
+
       watcher
 
   removeFolder: (relpath) ->


### PR DESCRIPTION
Add an empty handler to avoid crash.
In Windows, deleting a watched folder rise an [Error: watch EPERM].
(See https://github.com/joyent/node/issues/4337)
