### PR TITLE
monitor wasn't closed properly by monitor.close()

### DIFF
--- a/lib/watchers/node.iced
+++ b/lib/watchers/node.iced
@@ -13,7 +13,7 @@ class NodeWatcher extends EventEmitter
     @_broken = {}
 
   close: ->
-    for own relpath, watcher of @watchers
+    for own relpath, watcher of @_watchers
       watcher.close()
     @_watchers = null
 


### PR DESCRIPTION
`monitor.close()` doesn't stop watching the monitoring directory.

This bug is caused by a simple typo :sweat_drops:
